### PR TITLE
Resume with token message can get cumbersome

### DIFF
--- a/Sources/SQLiteSessions.swift
+++ b/Sources/SQLiteSessions.swift
@@ -120,7 +120,7 @@ public struct SQLiteSessions {
 	}
 
 	public func resume(token: String) -> PerfectSession {
-		print("Resume with token: \(token)")
+// 		print("Resume with token: \(token)")
 		var session = PerfectSession()
 		let proxy = PerfectSessionClass()
 		do {


### PR DESCRIPTION
Would love if this message is simply removed. Or if there is a global setting to turn off SQLite messages.